### PR TITLE
feat: configurable GLM models via settings, add GLM-5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@
 - Open the Command Palette and run `GLM: Set API Key` to configure your API credentials.
 - Use the provider from VS Code's Language Model Chat UI and select **Z.AI GLM**.
 
+## Custom models
+
+Built-in models (GLM-5.1, GLM-5, GLM-4.7, …) are always available. To expose an
+additional model without rebuilding the extension, add it to
+`glm-chat-provider.customModels` in `settings.json`. Only `id` is required; if
+an entry's `id` matches a built-in model, it overrides the built-in.
+
+```jsonc
+"glm-chat-provider.customModels": [
+  {
+    "id": "glm-5.1-air",
+    "name": "GLM-5.1 Air",
+    "version": "5.1-air",
+    "maxInputTokens": 200000,
+    "maxOutputTokens": 131072,
+    "imageInput": false,
+    "toolCalling": true
+  }
+]
+```
+
 ---
 
 ## License

--- a/package.json
+++ b/package.json
@@ -61,7 +61,66 @@
         "command": "glm-chat-provider.manage",
         "title": "GLM: Manage Provider"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "GLM Chat Provider",
+      "properties": {
+        "glm-chat-provider.customModels": {
+          "type": "array",
+          "default": [],
+          "markdownDescription": "Additional GLM models to expose in the chat model picker. Each entry requires `id` (sent to the Z.AI API as the model name) and optionally accepts `name`, `family`, `version`, `tooltip`, `detail`, `maxInputTokens`, `maxOutputTokens`, `imageInput`, and `toolCalling`. An entry whose `id` matches a built-in model overrides the built-in.",
+          "items": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Model id sent to the Z.AI API (e.g. \"glm-5.1\")."
+              },
+              "name": {
+                "type": "string",
+                "description": "Display name shown in the model picker. Defaults to id."
+              },
+              "family": {
+                "type": "string",
+                "default": "glm"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version label (defaults to id)."
+              },
+              "tooltip": {
+                "type": "string",
+                "default": "Z.AI"
+              },
+              "detail": {
+                "type": "string",
+                "default": "Z.AI"
+              },
+              "maxInputTokens": {
+                "type": "number",
+                "default": 200000
+              },
+              "maxOutputTokens": {
+                "type": "number",
+                "default": 131072
+              },
+              "imageInput": {
+                "type": "boolean",
+                "default": false
+              },
+              "toolCalling": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,163 @@
+import * as vscode from 'vscode';
+
+const CONFIG_SECTION = 'glm-chat-provider';
+const CUSTOM_MODELS_KEY = 'customModels';
+
+const DEFAULT_MAX_INPUT_TOKENS = 200000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 131072;
+const DEFAULT_FAMILY = 'glm';
+const DEFAULT_TOOLTIP = 'Z.AI';
+const DEFAULT_DETAIL = 'Z.AI';
+
+export interface CustomModelConfig {
+  id: string;
+  name?: string;
+  family?: string;
+  version?: string;
+  tooltip?: string;
+  detail?: string;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+  imageInput?: boolean;
+  toolCalling?: boolean;
+}
+
+export const DEFAULT_GLM_MODELS: vscode.LanguageModelChatInformation[] = [
+  {
+    id: 'glm-5.1',
+    name: 'GLM-5.1',
+    family: 'glm',
+    version: '5.1',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 200000,
+    maxOutputTokens: 131072,
+    capabilities: {imageInput: true, toolCalling: true},
+  },
+  {
+    id: 'glm-5',
+    name: 'GLM-5',
+    family: 'glm',
+    version: '5',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 200000,
+    maxOutputTokens: 131072,
+    capabilities: {imageInput: true, toolCalling: true},
+  },
+  {
+    id: 'glm-5-code',
+    name: 'GLM-5-Code',
+    family: 'glm',
+    version: '5-code',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 200000,
+    maxOutputTokens: 131072,
+    capabilities: {imageInput: true, toolCalling: true},
+  },
+  {
+    id: 'glm-4.7',
+    name: 'GLM-4.7',
+    family: 'glm',
+    version: '4.7',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 200000,
+    maxOutputTokens: 131072,
+    capabilities: {imageInput: false, toolCalling: true},
+  },
+  {
+    id: 'glm-4.7-flash',
+    name: 'GLM-4.7 Flash',
+    family: 'glm',
+    version: '4.7-flash',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 200000,
+    maxOutputTokens: 131072,
+    capabilities: {imageInput: false, toolCalling: true},
+  },
+  {
+    id: 'glm-4.6',
+    name: 'GLM-4.6',
+    family: 'glm',
+    version: '4.6',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 200000,
+    maxOutputTokens: 131072,
+    capabilities: {imageInput: false, toolCalling: true},
+  },
+  {
+    id: 'glm-4.5',
+    name: 'GLM-4.5',
+    family: 'glm',
+    version: '4.5',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 131072,
+    maxOutputTokens: 98304,
+    capabilities: {imageInput: false, toolCalling: true},
+  },
+  {
+    id: 'glm-4.5-air',
+    name: 'GLM-4.5 Air',
+    family: 'glm',
+    version: '4.5-air',
+    tooltip: 'Z.AI',
+    detail: 'Z.AI',
+    maxInputTokens: 131072,
+    maxOutputTokens: 98304,
+    capabilities: {imageInput: false, toolCalling: true},
+  },
+];
+
+function applyOverride(
+  base: vscode.LanguageModelChatInformation | undefined,
+  raw: CustomModelConfig,
+  id: string,
+): vscode.LanguageModelChatInformation {
+  return {
+    id,
+    name: raw.name ?? base?.name ?? id,
+    family: raw.family ?? base?.family ?? DEFAULT_FAMILY,
+    version: raw.version ?? base?.version ?? id,
+    tooltip: raw.tooltip ?? base?.tooltip ?? DEFAULT_TOOLTIP,
+    detail: raw.detail ?? base?.detail ?? DEFAULT_DETAIL,
+    maxInputTokens:
+      raw.maxInputTokens ?? base?.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS,
+    maxOutputTokens:
+      raw.maxOutputTokens ?? base?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    capabilities: {
+      imageInput: raw.imageInput ?? base?.capabilities?.imageInput ?? false,
+      toolCalling: raw.toolCalling ?? base?.capabilities?.toolCalling ?? true,
+    },
+  };
+}
+
+export function resolveGlmModels(): vscode.LanguageModelChatInformation[] {
+  const custom = vscode.workspace
+    .getConfiguration(CONFIG_SECTION)
+    .get<CustomModelConfig[]>(CUSTOM_MODELS_KEY, []);
+
+  const byId = new Map<string, vscode.LanguageModelChatInformation>();
+  for (const model of DEFAULT_GLM_MODELS) {
+    byId.set(model.id, model);
+  }
+
+  if (Array.isArray(custom)) {
+    for (const raw of custom) {
+      if (!raw || typeof raw.id !== 'string') {
+        continue;
+      }
+      const id = raw.id.trim();
+      if (id.length === 0) {
+        continue;
+      }
+      byId.set(id, applyOverride(byId.get(id), raw, id));
+    }
+  }
+
+  return [...byId.values()];
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import secureJsonParse from "secure-json-parse";
 import { P, match } from "ts-pattern";
 import { GlmApiClient, GlmApiError, type GlmMessage, type GlmTool, type GlmToolCall } from "./api";
+import { resolveGlmModels } from "./models";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions/completions";
 import type { AuthManager } from "./auth";
 
@@ -39,86 +40,6 @@ const THINK_OPEN = "<think>";
 const THINK_CLOSE = "</think>";
 const THINK_OPEN_MARKDOWN = "<details><summary>Thinking</summary>\n\n";
 const THINK_CLOSE_MARKDOWN = "\n\n</details>\n\n";
-
-const GLM_MODELS: vscode.LanguageModelChatInformation[] = [
-  {
-    id: "glm-5",
-    name: "GLM-5",
-    family: "glm",
-    version: "5",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 200000,
-    maxOutputTokens: 131072,
-    capabilities: { imageInput: true, toolCalling: true },
-  },
-  {
-    id: "glm-5-code",
-    name: "GLM-5-Code",
-    family: "glm",
-    version: "5-code",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 200000,
-    maxOutputTokens: 131072,
-    capabilities: { imageInput: true, toolCalling: true },
-  },
-  {
-    id: "glm-4.7",
-    name: "GLM-4.7",
-    family: "glm",
-    version: "4.7",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 200000,
-    maxOutputTokens: 131072,
-    capabilities: { imageInput: false, toolCalling: true },
-  },
-  {
-    id: "glm-4.7-flash",
-    name: "GLM-4.7 Flash",
-    family: "glm",
-    version: "4.7-flash",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 200000,
-    maxOutputTokens: 131072,
-    capabilities: { imageInput: false, toolCalling: true },
-  },
-  {
-    id: "glm-4.6",
-    name: "GLM-4.6",
-    family: "glm",
-    version: "4.6",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 200000,
-    maxOutputTokens: 131072,
-    capabilities: { imageInput: false, toolCalling: true },
-  },
-  {
-    id: "glm-4.5",
-    name: "GLM-4.5",
-    family: "glm",
-    version: "4.5",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 131072,
-    maxOutputTokens: 98304,
-    capabilities: { imageInput: false, toolCalling: true },
-  },
-  {
-    id: "glm-4.5-air",
-    name: "GLM-4.5 Air",
-    family: "glm",
-    version: "4.5-air",
-    tooltip: "Z.AI",
-    detail: "Z.AI",
-    maxInputTokens: 131072,
-    maxOutputTokens: 98304,
-    capabilities: { imageInput: false, toolCalling: true },
-  },
-];
 
 function getPartialSuffixLength(buffer: string, marker: string): number {
   for (let i = Math.min(buffer.length, marker.length - 1); i > 0; i--) {
@@ -492,7 +413,7 @@ export class GlmChatProvider implements vscode.LanguageModelChatProvider {
   }
 
   private modelsWithApiKey(apiKey: string): vscode.LanguageModelChatInformation[] {
-    return GLM_MODELS.map((model) => ({
+    return resolveGlmModels().map((model) => ({
       ...model,
       __glmApiKey: apiKey,
     }));


### PR DESCRIPTION
## Summary

Adds `glm-5.1` as a built-in model and introduces a new
`glm-chat-provider.customModels` setting so users can add or override
models through `settings.json` without rebuilding the extension.

Fixes #4 — `glm-5.1` ships out of the box, and `glm-5-turbo` (or any
future Z.AI model) can be enabled via user settings with no code change.

## Motivation

Every new Z.AI release previously required editing the hard-coded
`GLM_MODELS` array in `src/provider.ts` and re-publishing the extension.
Exposing the model list through VS Code's configuration schema means:

- Users can pick up new models the moment Z.AI ships them.
- Preview / internal-only models can be tried locally without forking.
- Built-in models remain curated defaults; user entries merge on top
  by `id`.

## What changed

- **GLM-5.1 added** to the default model list.
- **Model list moved** out of `src/provider.ts` into a new
  `src/models.ts` module.
- **New setting `glm-chat-provider.customModels`** declared in
  `package.json` with a typed JSON schema (`id` required;
  `name`, `family`, `version`, `tooltip`, `detail`, `maxInputTokens`,
  `maxOutputTokens`, `imageInput`, `toolCalling` optional;
  `additionalProperties: false`).
- **`resolveGlmModels()`** merges user entries over built-ins by `id`.
  When a custom entry shares an id with a built-in, unspecified fields
  inherit from the built-in (capabilities merged field-by-field), so
  partial overrides do not clobber token limits or capability flags.
- **Custom ids are trimmed once** and the trimmed value is used for
  both the map key and the emitted `model.id`, so a whitespace-padded
  id cannot silently shadow a built-in or reach the Z.AI API.
- **Invalid entries** (missing or empty `id`) are skipped; the rest of
  the list is unaffected.
- **README** documents the setting with an example.

## Compatibility

- `customModels` defaults to `[]`, so existing users see no behavior
  change.
- Built-in ids are unchanged (besides the GLM-5.1 addition). Existing
  chat sessions that reference a model id keep working.

## Example

```jsonc
"glm-chat-provider.customModels": [
  { "id": "glm-5-turbo" },
  { "id": "glm-5.1", "name": "GLM-5.1 (Preview)" }
]
```

The first entry exposes `glm-5-turbo` with generic defaults; the second
overrides only the display name of the built-in `glm-5.1` while
preserving its capabilities and token limits.

## Test plan

- [x] `npm run compile` — clean
- [x] Packaged locally with `vsce package` and installed the `.vsix`
      in VS Code
- [x] `GLM: Set API Key` works; GLM-5.1 appears in the chat model
      picker
- [x] Adding a `customModels` entry shows the new model on the next
      picker open (no window reload required)
- [x] An entry with an id matching a built-in overrides only the
      fields provided; others inherit from the built-in
- [x] Entries with missing / empty `id` are skipped without breaking
      the rest of the list
- [x] Whitespace-padded ids (`"  glm-5.1  "`) correctly match
      built-ins and are emitted trimmed